### PR TITLE
Make Commands on the homepage more easily copyable

### DIFF
--- a/frontend/components/box.tsx
+++ b/frontend/components/box.tsx
@@ -12,11 +12,11 @@ export const Box = ({
   <div
     className={cx(
       "shadow-drop rounded-[40px] px-5 py-5 ",
-      "border border-black dark:bg-dark-gray md:grid grid-cols-[1fr_2fr]",
+      "border border-black dark:bg-dark-gray lg:grid grid-cols-[1fr_2fr] gap-4",
       className
     )}
   >
-    <h1 className="font-heading text-4xl font-bold mt-5 mb-10 md:m-0 md:text-5xl md:px-10 md:flex items-center">
+    <h1 className="font-heading text-4xl font-bold mt-5 mb-10 lg:m-0 lg:text-5xl lg:flex items-center">
       {title}
     </h1>
     <div className="text-2xl">{children}</div>

--- a/frontend/components/command.stories.tsx
+++ b/frontend/components/command.stories.tsx
@@ -1,0 +1,10 @@
+import { ComponentMeta } from "@storybook/react";
+
+import { Command } from "./command";
+
+export default {
+  title: "Command",
+  component: Command,
+} as ComponentMeta<typeof Command>;
+
+export const Primary = () => <Command text="curl -Lfs latest.cat/python" />;

--- a/frontend/components/command.tsx
+++ b/frontend/components/command.tsx
@@ -1,14 +1,12 @@
 export const Command = ({ text }: { text: string }) => (
-  <div className="flex flex-col sm:flex-row items-baseline justify-between">
-    <div className="mb-4 flex overflow-auto text-[1rem] sm:text-[1em]">
-      <span className="mr-2 sm:mr-4 select-none">$</span>
-      <pre>
-        <code>{text}</code>
-      </pre>
-    </div>
+  <div className="mb-4 flex overflow-scroll md:overflow-auto w-full">
+    <span className="mr-2 sm:mr-4 select-none">$</span>
+    <pre>
+      <code>{text}</code>
+    </pre>
     <button
       onClick={() => navigator.clipboard.writeText(text)}
-      className="px-2 py-1 font-heading font-medium rounded-full hidden sm:inline hover:bg-gray text-black transition active:bg-dark-gray active:text-white"
+      className="ml-auto px-2 py-1 font-heading font-medium rounded-full hidden sm:inline hover:bg-gray text-black transition active:bg-dark-gray active:text-white items-center"
     >
       Copy
     </button>

--- a/frontend/components/command.tsx
+++ b/frontend/components/command.tsx
@@ -1,14 +1,14 @@
 export const Command = ({ text }: { text: string }) => (
   <div className="flex flex-col sm:flex-row items-baseline justify-between">
-    <div className="mb-4 flex overflow-auto">
-      <span className="mr-4 select-none">$</span>
+    <div className="mb-4 flex overflow-auto text-[1rem] sm:text-[1em]">
+      <span className="mr-2 sm:mr-4 select-none">$</span>
       <pre>
         <code>{text}</code>
       </pre>
     </div>
     <button
       onClick={() => navigator.clipboard.writeText(text)}
-      className="px-2 py-1 font-heading font-medium rounded-full hover:bg-gray text-black transition active:bg-dark-gray active:text-white"
+      className="px-2 py-1 font-heading font-medium rounded-full hidden sm:inline hover:bg-gray text-black transition active:bg-dark-gray active:text-white"
     >
       Copy
     </button>

--- a/frontend/components/command.tsx
+++ b/frontend/components/command.tsx
@@ -1,0 +1,16 @@
+export const Command = ({ text }: { text: string }) => (
+  <div className="flex flex-col sm:flex-row items-baseline justify-between">
+    <div className="mb-4 flex overflow-auto">
+      <span className="mr-4 select-none">$</span>
+      <pre>
+        <code>{text}</code>
+      </pre>
+    </div>
+    <button
+      onClick={() => navigator.clipboard.writeText(text)}
+      className="px-2 py-1 font-heading font-medium rounded-full hover:bg-gray text-black transition active:bg-dark-gray active:text-white"
+    >
+      Copy
+    </button>
+  </div>
+);

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -8,6 +8,7 @@ import { SearchInput } from "components/search-input";
 import { FormEventHandler } from "react";
 import { AboutBox } from "components/about-box";
 import { Meta } from "components/meta";
+import { Command } from "components/command";
 
 const Home: NextPage = () => {
   const goToSoftware: FormEventHandler<HTMLFormElement> = (event) => {
@@ -42,25 +43,12 @@ const Home: NextPage = () => {
             <p className="mb-4 font-bold">
               You can also use latest.cat from the command line:
             </p>
-            <div>
-              <div className="mb-4 flex overflow-auto">
-                <span className="mr-4 select-none">$</span>
-                <pre>
-                  <code>curl -Lfs latest.cat/python</code>
-                </pre>
-              </div>
-            </div>
+            <Command text="curl -Lfs latest.cat/python" />
             <div>
               <p className="mb-4 font-bold">
                 And you can even filter the results by version number:
               </p>
-
-              <div className="mb-4 flex overflow-auto">
-                <span className="mr-4 select-none">$</span>
-                <pre>
-                  <code>curl -Lfs latest.cat/python/3.6</code>
-                </pre>
-              </div>
+              <Command text="curl -Lfs latest.cat/python/3.6" />
             </div>
           </Box>
 

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -43,7 +43,7 @@ const Home: NextPage = () => {
               You can also use latest.cat from the command line:
             </p>
             <div>
-              <div className="mb-4 flex overflow-scroll">
+              <div className="mb-4 flex overflow-auto">
                 <span className="mr-4 select-none">$</span>
                 <pre>
                   <code>curl -Lfs latest.cat/python</code>
@@ -55,7 +55,7 @@ const Home: NextPage = () => {
                 And you can even filter the results by version number:
               </p>
 
-              <div className="mb-4 flex overflow-scroll">
+              <div className="mb-4 flex overflow-auto">
                 <span className="mr-4 select-none">$</span>
                 <pre>
                   <code>curl -Lfs latest.cat/python/3.6</code>


### PR DESCRIPTION
👋🏻 Hi! I really enjoy this project. Just heard about it while watching the PyCon lightning talks on YouTube. I thought I would try and make it easier for users to copy the `cURL` commands that are listed on the home page. 

I did this by extracting out a `Command` component, adding a Storybook story as the other components had. Here is how it looks on the home page:

![The latest.cat homepage with cURL commands and a copy button.](https://user-images.githubusercontent.com/29112081/169947741-f254ae6b-dc5e-4015-bbcf-3bbc4406091d.png)

I took the button design from the `Search` component, but I also added an "on click" style.

Hovered:
![The copy button has a rounded, grey background when hovered.](https://user-images.githubusercontent.com/29112081/169947889-f155bc87-c926-4475-a97d-4cf0bd7d370e.png)

Clicked:
![image](https://user-images.githubusercontent.com/29112081/169948042-baf5a490-eac3-4c2e-83b7-725511c8c5d5.png)

I used the [Async Clipboard API](https://caniuse.com/?search=async%20clipboard) for simplicity. There are fallbacks I am happy to add, but I figure the users you are targeting will likely be using a browser that supports the API.

I also changed the overflow styling of the code text box. Before, on Windows, you would always see scroll bars because it was set to `overflow-scroll`. I changed it to `overflow-auto` so you only see the scroll bars if the content cannot fully be displayed.

Before the change (on Windows):
![image](https://user-images.githubusercontent.com/29112081/169948270-3ab663f2-79c7-4860-92e8-65497f27d8b7.png)

Feel free to change/ditch/ask for changes/whatever. I am just down to help out.

